### PR TITLE
Fix 'Missing compiler' if there is only one html in link

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,5 +124,5 @@ function children(token) {
 
 /* Return nothing. */
 function empty() {
-  return null;
+  return {type: 'text', value: ''};
 }

--- a/test.js
+++ b/test.js
@@ -60,6 +60,7 @@ test('stripMarkdown()', function (t) {
   t.equal(proc('```js\nconsole.log("world");\n```'), '', 'code (2)');
   t.equal(proc('<sup>Hello</sup>'), 'Hello', 'html (1)');
   t.equal(proc('<script>alert("world");</script>'), '', 'html (2)');
+  t.equal(proc('[<img src="http://example.com/a.jpg" />](http://example.com)'), '', 'html (3)');
 
   t.end();
 });


### PR DESCRIPTION
When I use strip-markdown for https://github.com/callemall/material-ui/blame/v0.16.0/README.md#L158,
I get "Missing compiler for node of type `undefined`: ``".
This PR solves the issue.
