### PR TITLE
Fix 'Invalid type' on empty list item

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ function all(nodes) {
   while (++index < length) {
     value = one(nodes[index]);
 
-    if (value && value.length) {
+    if (value && typeof value.length === 'number') {
       result = result.concat(value.map(one));
     } else if (value) {
       result.push(value);

--- a/test.js
+++ b/test.js
@@ -45,6 +45,12 @@ test('stripMarkdown()', function (t) {
   );
 
   t.equal(
+    proc('- Hello\n- \n- World!'),
+    'Hello\n\nWorld!',
+    'empty list item'
+  );
+
+  t.equal(
     proc('> Hello\n> World\n> !'),
     'Hello\nWorld\n!',
     'blockquote'


### PR DESCRIPTION
If mdast has an empty children, strip-markdown raises `Invalid type: undefined`.
The minimum example is `-` (hyphen and space).

``` js
// Some attributes are removed for simplicity
{ type: 'root',
  children:
   [ { type: 'list',
       children:
        [ { type: 'listItem',
            children: [] } ], }, ], }
```

```
Error: Invalid type: undefined
 at one (node_modules\strip-markdown\index.js:39:11)
 at Array.map (native)
 at all (node_modules\strip-markdown\index.js:66:36)
 at one (node_modules\strip-markdown\index.js:48:23)
```
