### PR TITLE
Support reference-style link

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,10 +24,10 @@ map.text = map.inlineCode = text;
 map.image = image;
 
 map.blockquote = map.list = map.listItem = map.strong =
-  map.emphasis = map.delete = map.link = children;
+  map.emphasis = map.delete = map.link = map.linkReference = children;
 
 map.code = map.horizontalRule = map.thematicBreak = map.html =
-  map.table = map.tableCell = empty;
+  map.table = map.tableCell = map.definition = empty;
 
 /* One node. */
 function one(node) {

--- a/test.js
+++ b/test.js
@@ -45,6 +45,7 @@ test('stripMarkdown()', function (t) {
   t.equal(proc('`Alfred`'), 'Alfred', 'inline code');
   t.equal(proc('[Hello](world)'), 'Hello', 'link');
   t.equal(proc('[**H**ello](world)'), 'Hello', 'importance in link');
+  t.equal(proc('[Hello][id]\n\n[id]: http://example.com "optional title"'), 'Hello', 'reference-style link');
   t.equal(proc('Hello.\n\nWorld.'), 'Hello.\n\nWorld.', 'paragraph');
   t.equal(proc('## Alfred'), 'Alfred', 'headings (atx)');
   t.equal(proc('Alfred\n====='), 'Alfred', 'headings (setext)');


### PR DESCRIPTION
This PR makes strip-markdown support reference-style links.
I fetched 30,000 markdown files from GitHub.
Roughly 10% of them use reference-style links.
