### PR TITLE
Support reference-style image

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var map = {};
 
 map.heading = paragraph;
 map.text = map.inlineCode = text;
-map.image = image;
+map.image = map.imageReference = image;
 
 map.blockquote = map.list = map.listItem = map.strong =
   map.emphasis = map.delete = map.link = map.linkReference = children;

--- a/test.js
+++ b/test.js
@@ -77,6 +77,7 @@ test('stripMarkdown()', function (t) {
   t.equal(proc('![An image](image.png "test")'), 'An image', 'image (1)');
   t.equal(proc('![](image.png "test")'), 'test', 'image (2)');
   t.equal(proc('![](image.png)'), '', 'image (3)');
+  t.equal(proc('![An image][id]\n\n[id]: http://example.com/a.jpg'), 'An image', 'reference-style image');
 
   t.equal(proc('---'), '', 'thematic break');
   t.equal(proc('| A | B |\n| - | - |\n| C | D |'), '', 'table');


### PR DESCRIPTION
This PR will make strip-markdown support reference-style images.
2 or 3 % of 30,000 markdown files uses reference-style images.
