### PR TITLE
Support hard line break

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var map = {};
 map.heading = paragraph;
 map.text = map.inlineCode = text;
 map.image = map.imageReference = image;
+map.break = lineBreak;
 
 map.blockquote = map.list = map.listItem = map.strong =
   map.emphasis = map.delete = map.link = map.linkReference = children;
@@ -116,6 +117,11 @@ function paragraph(token) {
 /* Return the concatenation of `token`s children. */
 function children(token) {
   return token.children;
+}
+
+/* Return line break. */
+function lineBreak() {
+  return {type: 'text', value: '\n'};
 }
 
 /* Return nothing. */

--- a/test.js
+++ b/test.js
@@ -80,6 +80,8 @@ test('stripMarkdown()', function (t) {
   t.equal(proc('![An image][id]\n\n[id]: http://example.com/a.jpg'), 'An image', 'reference-style image');
 
   t.equal(proc('---'), '', 'thematic break');
+  t.equal(proc('A  \nB'), 'A\nB', 'hard line break');
+  t.equal(proc('A\nB'), 'A\nB', 'soft line break');
   t.equal(proc('| A | B |\n| - | - |\n| C | D |'), '', 'table');
   t.equal(proc('\talert("hello");'), '', 'code (1)');
   t.equal(proc('```js\nconsole.log("world");\n```'), '', 'code (2)');


### PR DESCRIPTION
GitHub Flavored Markdown does not require hard line breaks,
but some people uses hard line breaks.
