### PR TITLE
Ignore yaml node

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ map.blockquote = map.list = map.listItem = map.strong =
   map.emphasis = map.delete = map.link = map.linkReference = children;
 
 map.code = map.horizontalRule = map.thematicBreak = map.html =
-  map.table = map.tableCell = map.definition = empty;
+  map.table = map.tableCell = map.definition = map.yaml = empty;
 
 /* One node. */
 function one(node) {

--- a/test.js
+++ b/test.js
@@ -86,6 +86,7 @@ test('stripMarkdown()', function (t) {
   t.equal(proc('<sup>Hello</sup>'), 'Hello', 'html (1)');
   t.equal(proc('<script>alert("world");</script>'), '', 'html (2)');
   t.equal(proc('[<img src="http://example.com/a.jpg" />](http://example.com)'), '', 'html (3)');
+  t.equal(proc('---\ntitle: title\ndescription: description\n---'), '', 'yaml');
 
   t.end();
 });


### PR DESCRIPTION
We can ignore metadata.

With this PR and #6,
all of 30,000 markdown files except 5 can be parsed.
Those 5 files contain tab characters.
It will be solved by wooorm/remark#198.
