### PR TITLE
Add option to remove or replace node types

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,18 +38,34 @@ var defaults = {
 var own = {}.hasOwnProperty
 
 function strip(options) {
-  var keep = (options || {}).keep || []
+  var handlers = {}
   var map = {}
+  var settings = options || {}
+  var remove = settings.remove || []
+  var keep = settings.keep || []
   var length = keep.length
   var index = -1
   var key
 
-  if (length === 0) {
-    map = defaults
+  if (remove.length === 0) {
+    handlers = defaults
   } else {
-    for (key in defaults) {
+    handlers = Object.assign({}, defaults)
+    remove.forEach((name) => {
+      if (Array.isArray(name)) {
+        handlers[name[0]] = name[1]
+      } else {
+        handlers[name] = empty
+      }
+    })
+  }
+
+  if (length === 0) {
+    map = handlers
+  } else {
+    for (key in handlers) {
       if (keep.indexOf(key) === -1) {
-        map[key] = defaults[key]
+        map[key] = handlers[key]
       }
     }
 
@@ -57,7 +73,7 @@ function strip(options) {
     while (++index < length) {
       key = keep[index]
 
-      if (!own.call(defaults, key)) {
+      if (!own.call(handlers, key)) {
         throw new Error(
           'Invalid `keep` option: No modifier is defined for node type `' +
             key +

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prettier": "^2.0.0",
     "remark": "^13.0.0",
     "remark-cli": "^9.0.0",
+    "remark-directive": "^1.0.0",
     "remark-footnotes": "^3.0.0",
     "remark-gfm": "^1.0.0",
     "remark-preset-wooorm": "^8.0.0",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,7 @@
 // TypeScript Version: 3.0
 
 import {Plugin} from 'unified'
+import {Node} from 'unist'
 
 declare namespace strip {
   interface Options {
@@ -34,6 +35,11 @@ declare namespace strip {
       | 'footnoteReference'
       | 'footnoteDefinition'
     >
+
+    /**
+     * List of additional node types to remove or replace.
+     */
+    remove?: Array<string | [string, (node: Node) => Node]>
   }
 }
 

--- a/types/test.ts
+++ b/types/test.ts
@@ -4,5 +4,8 @@ import strip = require('strip-markdown')
 remark().use(strip)
 remark().use(strip, {keep: []})
 remark().use(strip, {keep: [`table`]})
+remark().use(strip, {remove: [`textDirective`]})
+remark().use(strip, {remove: [[`textDirective`, (node) => node]]})
 
 remark().use(strip, {keep: [`typo`]}) // $ExpectError
+remark().use(strip, {remove: [[`textDirective`, 'containerDirective']]}) // $ExpectError


### PR DESCRIPTION
follow-up to #25

this pr suggests a new `remove` option to mirror the current `keep` option. it allows stripping custom node types (e.g. like directives).

also added the possibility to replace node types, which might be useful in case of directives (see the last test as an example), however i am unsure if this is out-of-scope for this plugin, or if it would be better to just accept a `handlers` option then.